### PR TITLE
Triton benchmark metrics

### DIFF
--- a/.install.sh
+++ b/.install.sh
@@ -72,6 +72,5 @@ INSTALL_PYTHON=$VENV_NAME/bin/python
 source $VENV_NAME/bin/activate
 install_pip_packages
 make_kernel
-install_treemaker
 unset INSTALL_PYTHON
 

--- a/jupy.sh
+++ b/jupy.sh
@@ -12,6 +12,6 @@ TOKEN=$(od -vN "16" -An -tx1 /dev/urandom | tr -d " \n")
 echo "Server url: http://127.0.0.1:${PORT}/?token=${TOKEN}"
 echo ""
 
-jupyter notebook --ip 0.0.0.0 --port ${PORT} \
+jupyter lab --ip 0.0.0.0 --port ${PORT} \
 	--no-browser --notebook-dir . \
 	--NotebookApp.token=$TOKEN

--- a/notebooks/generate_pseudodata.ipynb
+++ b/notebooks/generate_pseudodata.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86563f20-ee9f-4950-801c-5baec864a78a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import uproot\n",
+    "import awkward as ak\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d534f0c6-c995-41f2-8518-28949357f2a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def generate_pseudodata_from_njets(njets):\n",
+    "    total_jets = np.sum(njets)    \n",
+    "    points = ak.unflatten(grdn.random((total_jets, 2, 100), dtype=np.float32), njets)\n",
+    "    features = ak.unflatten(grdn.random((total_jets, 5, 100), dtype=np.float32), njets)\n",
+    "    mask = ak.unflatten(grdn.random((total_jets, 1, 100), dtype=np.float32), njets)\n",
+    "    return ak.Array({\"points\": points,\n",
+    "            \"features\": features,\n",
+    "            \"mask\": mask})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72c1eee0-859d-4de2-8fb4-d80501b26011",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "FILE_BASE = \"../data/PseudoData_{nfile}.root\"\n",
+    "N_FILES = 100\n",
+    "N_EVENTS_PER_BASKET = 2_000\n",
+    "N_BASKETS = 20\n",
+    "\n",
+    "grdn = np.random.default_rng()\n",
+    "file_names = []\n",
+    "\n",
+    "for nfile in range(N_FILES):\n",
+    "    file_name = FILE_BASE.format(nfile=nfile)\n",
+    "    file = uproot.recreate(file_name, compression = uproot.ZLIB(1))\n",
+    "    print(\"Writing file...\", file_name)\n",
+    "    for nbasket in range(N_BASKETS):\n",
+    "        grdn = np.random.default_rng([nfile, nbasket])\n",
+    "        njets = ak.Array(grdn.integers(1, 10, size=N_EVENTS_PER_BASKET))\n",
+    "        if nbasket == 0:\n",
+    "            file[\"Events\"] = {\"Jet\": njets}\n",
+    "        else:\n",
+    "            file[\"Events\"].extend({\"Jet\": njets})\n",
+    "    file.close()\n",
+    "    file_names.append(file_name)\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d94c39e5-0a6e-4044-b597-7e6b4ecf3e26",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ftest = uproot.open(\"../data/PseudoDataSeeds_99.root\")\n",
+    "treetest = ftest[\"Events\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "285904f1-8a5a-4ee1-9265-6322d0f12055",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(ftest.keys(), treetest.keys(), treetest.num_entries)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "coffea for triton",
+   "language": "python",
+   "name": "coffea-triton"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/run_benchmark_MU_SM.ipynb
+++ b/notebooks/run_benchmark_MU_SM.ipynb
@@ -1,0 +1,358 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc4a7a1-2167-4ee2-9e79-acc1d10d70e0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from distributed import Client\n",
+    "from lpcjobqueue import LPCCondorCluster\n",
+    "import awkward as ak\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from utils.mlbench import SimpleWorkLog\n",
+    "from utils.mlbench import process_function, create_local_pnmodel, get_triton_client, run_inference_pnmodel, generate_pseudodata_from_seed\n",
+    "import time\n",
+    "import pathlib\n",
+    "#Can use ship_env and the .triton_env with LPCCondorCluster, but here's an alternative that should work for other cluster types\n",
+    "from distributed.diagnostics.plugin import UploadDirectory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "322e9b8f-a1b9-4b57-b235-78c877f06199",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster = LPCCondorCluster(cores=2, \n",
+    "                           memory=\"7.5GB\", \n",
+    "                           disk=\"4GB\", \n",
+    "                           log_directory='/uscmst1b_scratch/lpc1/3DayLifetime/'+str(os.getlogin),\n",
+    "                           #ship_env=False,\n",
+    "                           #death_timeout=240,\n",
+    "                           #schedule_options={\"dashboard_address\": f\":{__get_port():d}\"},\n",
+    "                          )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b28c42a9-7e10-4021-924b-507d17ec0591",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster.adapt(minimum=50, maximum=50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f179a1c1-a5f4-477f-ae46-ee79fb08c918",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster.workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f79a33d6-70a6-4587-b2bb-c7abd0e30007",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "client = Client(cluster)\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f14dfcd7-a133-4e02-b16a-6b40705ba155",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "client.register_worker_plugin(UploadDirectory(\"../utils\",restart=True,update_path=True), nanny=True) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "792f0964-91a8-46bd-852a-36b9d9170c43",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "client.register_worker_plugin(UploadDirectory(\"../models\",restart=True,update_path=True), nanny=True)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c37269d9-6e89-4e09-9558-190bba792464",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def test_structure(x):\n",
+    "    import os\n",
+    "    import sys\n",
+    "    import pathlib\n",
+    "    test = pathlib.Path(\"/srv/utils/\")\n",
+    "    success = False\n",
+    "    try:\n",
+    "        from srv.utils.mlbench import SimpleWorkLog\n",
+    "        success = True\n",
+    "    except:\n",
+    "        pass\n",
+    "    success2 = False\n",
+    "    try:\n",
+    "        from utils.mlbench import SimpleWorkLog\n",
+    "        success2 = True\n",
+    "    except:\n",
+    "        pass\n",
+    "    success3 = False\n",
+    "    try:\n",
+    "        from mlbench import SimpleWorkLog\n",
+    "        success3 = True\n",
+    "    except:\n",
+    "        pass\n",
+    "    \n",
+    "    return os.environ, sys.path, success, success2, success3, list(test.iterdir())\n",
+    "\n",
+    "def test_triton_dask(worker):\n",
+    "    x = get_triton_client()\n",
+    "    if x is not None:\n",
+    "        return \"success\"\n",
+    "    else:\n",
+    "        return type(x)\n",
+    "\n",
+    "def print_cluster_info(cluster):\n",
+    "    for key in cluster.scheduler_info.keys():\n",
+    "        if key not in [\"workers\"]:\n",
+    "            print(key, cluster.scheduler_info[key])\n",
+    "        else:\n",
+    "            print(key)\n",
+    "            for address, details in cluster.scheduler_info[key].items():\n",
+    "                print(\"\\t\", address)\n",
+    "                maxdkey = max([len(dkey) for dkey in details])\n",
+    "                for dkey, dval in details.items():\n",
+    "                    diff = maxdkey - len(dkey)\n",
+    "                    extras = \" \"*diff\n",
+    "                    extras += \"  =\\t\"    \n",
+    "                    print(\"\\t\\t\", dkey, extras, dval)\n",
+    "def test_workers(x):\n",
+    "    results = {}\n",
+    "    try:\n",
+    "        import os\n",
+    "        results[\"pid\"] = os.getpid()\n",
+    "    except:\n",
+    "        results[\"pid\"] = False\n",
+    "        \n",
+    "    import socket\n",
+    "    try:\n",
+    "        import socket\n",
+    "        results[\"hostname\"] = socket.gethostname()\n",
+    "    except:\n",
+    "        results[\"hostname\"] = False\n",
+    "        \n",
+    "    try:\n",
+    "        from utils.mlbench import SimpleWorkLog\n",
+    "        results[\"utils\"] = True\n",
+    "    except:\n",
+    "        results[\"utils\"] = False\n",
+    "        \n",
+    "    try:\n",
+    "        from utils.mlbench import get_triton_client\n",
+    "        _ = get_triton_client()\n",
+    "        results[\"triton\"] = True\n",
+    "    except:\n",
+    "        results[\"triton\"] = False\n",
+    "        \n",
+    "    try:\n",
+    "        from utils.mlbench import create_local_pnmodel\n",
+    "        _ = create_local_pnmodel()\n",
+    "        results[\"local\"] = True\n",
+    "    except:\n",
+    "        results[\"local\"] = False\n",
+    "    \n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fe14ea2-8bf9-4e9e-a561-6415dafb0864",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Test the workers can perform basic functions\n",
+    "test = client.gather(client.map(test_workers, range(len(cluster.workers))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c6be47b-9118-4bb0-9fb8-c33b83b8d7e0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "unique_workers = {}\n",
+    "for r in test:\n",
+    "    unique_workers[r['hostname']+str(r['pid'])] = r\n",
+    "n_workers = len(unique_workers.keys())\n",
+    "n_utils_imports = sum([r['utils'] for r in unique_workers.values()])\n",
+    "n_triton_functioning = sum([r['triton'] for r in unique_workers.values()])\n",
+    "n_local_functioning = sum([r['local'] for r in unique_workers.values()])\n",
+    "n_workers, n_utils_imports, n_triton_functioning, n_local_functioning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03499eb7-cf02-49d4-905d-0e662f3e0e55",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "n_workers = 100\n",
+    "long_multiplier = 10\n",
+    "#seeds, #pseudo-events, batchsize, use triton (True/False)\n",
+    "workargstriton = [range(n_workers), [1000]*n_workers, [1000]*n_workers, [True]*n_workers]\n",
+    "workargslocal = [range(n_workers), [1000]*n_workers, [250]*n_workers, [False]*n_workers]\n",
+    "workargstritonlong =  [range(n_workers*long_multiplier), \n",
+    "                      [9999]*n_workers*long_multiplier, \n",
+    "                      [1000]*n_workers*long_multiplier, \n",
+    "                      [True]*n_workers*long_multiplier]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9bae7f94-a3d8-4588-87e6-eb77dd1a662e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with_outputs, inf_worklogs, errors = run_inference_pnmodel(\n",
+    "    generate_pseudodata_from_seed(983, 1000), \n",
+    "    get_triton_client(), \n",
+    "    batchsize=1000, \n",
+    "    triton=True, \n",
+    "    worklog=SimpleWorkLog\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97852189-d1e9-47c1-b954-2643c1a92ce7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Triton, N workers trial\n",
+    "print(\"time\", time.time())\n",
+    "pft = time.perf_counter()\n",
+    "futurestriton = client.map(process_function, *workargstriton)\n",
+    "resulttriton = client.gather(futurestriton)\n",
+    "print(\"runtime(s)\", time.perf_counter() - pft)\n",
+    "print(\"time\", time.time())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d10ab7ff",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Triton, N workers trial long\n",
+    "print(\"time\", time.time())\n",
+    "pft = time.perf_counter()\n",
+    "futurestlong = client.map(process_function, *workargstritonlong)\n",
+    "resulttlong = client.gather(futurestlong)\n",
+    "print(\"runtime(s)\", time.perf_counter() - pft)\n",
+    "print(\"time\", time.time())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ce99067-75c5-4bf2-8935-5621356fbdd8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Local, N workers trial\n",
+    "print(\"time\", time.time())\n",
+    "pfl = time.perf_counter()\n",
+    "futureslocal = client.map(process_function, *workargslocal)\n",
+    "resultlocal = client.gather(futureslocal)\n",
+    "print(\"runtime(s)\", time.perf_counter() - pfl)\n",
+    "print(\"time\", time.time())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf6e0095-faa4-4579-8e9a-d4ea8f75cb2c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "coffea for triton",
+   "language": "python",
+   "name": "coffea-triton"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/triton_prometheus_queries.ipynb
+++ b/notebooks/triton_prometheus_queries.ipynb
@@ -1,0 +1,396 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c2c7aa-75a0-45aa-9cc2-e7214dbb41ea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "import json\n",
+    "import prometheus_api_client\n",
+    "from prometheus_api_client import PrometheusConnect\n",
+    "from prometheus_api_client.metric_range_df import MetricRangeDataFrame\n",
+    "from prometheus_api_client.metric_snapshot_df import MetricSnapshotDataFrame\n",
+    "from prometheus_api_client.metrics_list import MetricsList\n",
+    "from prometheus_api_client.utils import parse_datetime\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ab8010b-3b64-4c9c-9733-933144858a04",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "prom = PrometheusConnect(url=\"http://lsdataitb.fnal.gov:9009/prometheus\", disable_ssl=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b7c85d9-0dc5-42f0-b43d-0476e5836864",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "xxx = prom.all_metrics()\n",
+    "len(xxx)\n",
+    "[xx for xx in xxx if \"GPU\" in xx or \"DCGM\" in xx]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "443f2046-6e41-4340-b8cc-94ebfd43a5fb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def get_all_queries(timestamp_tuples, step):\n",
+    "    results = {}\n",
+    "    queries = []\n",
+    "    timestamp_tuples = [(\"2023-03-30 at 16:00:00 MDT\", \"2023-03-30 at 19:00:00 MDT\"),\n",
+    "                       ]\n",
+    "    unique_model_versions = None\n",
+    "    unique_gpu_instances = None\n",
+    "    for key, query in {\n",
+    "        \"num_instances\": \"count((sum by(pod) (delta(nv_inference_request_success[\"+step+\"]))) > 0)\",\n",
+    "        \"inf_rate_net\":\"sum (rate(nv_inference_count[\"+step+\"]))\",\n",
+    "        \"inf_rate_bypod\":\"sum by(pod) (rate(nv_inference_count[\"+step+\"]))\",\n",
+    "        \"inf_rate\":\"sum by(model, version, pod) (rate(nv_inference_count[\"+step+\"]))\",\n",
+    "        \"inf_cache_hit_rate\":\"sum by(model, version, pod) (rate(nv_cache_num_hits_per_model[\"+step+\"]))\",\n",
+    "        \"inf_reqs_net\":\"sum(rate(nv_inference_request_success[\"+step+\"]))\",\n",
+    "        \"inf_reqs_bypod\":\"sum by(pod) (rate(nv_inference_request_success[\"+step+\"]))\",\n",
+    "        \"inf_reqs\":\"sum by(model, version, pod) (rate(nv_inference_request_success[\"+step+\"]))\",\n",
+    "        \"inf_req_dur_net\": \"avg (delta(nv_inference_request_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_que_dur_net\": \"avg (delta(nv_inference_queue_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_inp_dur_net\": \"avg (delta(nv_inference_compute_input_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_inf_dur_net\": \"avg (delta(nv_inference_compute_infer_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_out_dur_net\": \"avg (delta(nv_inference_compute_output_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_req_dur\": \"avg by(model, version, pod) (delta(nv_inference_request_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_que_dur\": \"avg by(model, version, pod) (delta(nv_inference_queue_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_inp_dur\": \"avg by(model, version, pod) (delta(nv_inference_compute_input_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_inf_dur\": \"avg by(model, version, pod) (delta(nv_inference_compute_infer_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"inf_out_dur\": \"avg by(model, version, pod) (delta(nv_inference_compute_output_duration_us[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        \"gpu_tensor_util\": \"sum by(device,GPU_I_ID,instance) (avg_over_time (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{exported_container='triton',exported_namespace='triton',prometheus_replica='prometheus-k8s-0'}[\"+step+\"]))\",\n",
+    "        \"gpu_dram_util\": \"sum by(device,GPU_I_ID,instance) (avg_over_time (DCGM_FI_PROF_DRAM_ACTIVE{exported_container='triton',exported_namespace='triton',prometheus_replica='prometheus-k8s-0'}[\"+step+\"]))\",\n",
+    "        #\"inf_cache_hits\": \"avg by(model, version, pod) (delta(nv_cache_num_hits_per_model[\"+step+\"])/(1+1000000*delta(nv_inference_request_success[\"+step+\"])))\",\n",
+    "        }.items():\n",
+    "        results[key] = []\n",
+    "        queries.append((key, query))\n",
+    "        for st, et in timestamp_tuples:\n",
+    "            test_inp = prom.custom_query_range(\n",
+    "                query=query,\n",
+    "                start_time=parse_datetime(st),\n",
+    "                end_time=parse_datetime(et),\n",
+    "                step=step\n",
+    "            )\n",
+    "            df = MetricRangeDataFrame(test_inp)\n",
+    "            results[key].append(df)\n",
+    "        results[key] = pd.concat(results[key], axis=0)\n",
+    "        if unique_model_versions is None and hasattr(results[key], \"model\") and hasattr(results[key], \"version\"):\n",
+    "            unique_model_versions = set((results[key].model+\"/\"+results[key].version).values)\n",
+    "        if unique_gpu_instances is None and hasattr(results[key], \"GPU_I_ID\"):\n",
+    "            unique_gpu_instances = set((results[key].device+\"/\"+results[key].GPU_I_ID+\"/\"+results[key].instance).values)\n",
+    "    model_queries = {\"num_instances_\"+model_version: \"count((sum by(pod) (delta(nv_inference_request_success{model='\"+\n",
+    "                     model_version.split(\"/\")[0]+\"',version='\"+model_version.split(\"/\")[1]+\"'}[\"+step+\"]))) > 0)\"\n",
+    "                     for model_version in unique_model_versions}\n",
+    "    model_queries.update(\n",
+    "        {\"inf_rate_\"+model_version: \"sum (rate(nv_inference_count{model='\"+\n",
+    "         model_version.split(\"/\")[0]+\"',version='\"+model_version.split(\"/\")[1]+\"'}[\"+step+\"]))\"\n",
+    "         for model_version in unique_model_versions})\n",
+    "    for key, query in model_queries.items():\n",
+    "        queries.append((key, query))\n",
+    "        results[key] = []\n",
+    "        for st, et in timestamp_tuples:\n",
+    "            test_inp = prom.custom_query_range(\n",
+    "                query=query,\n",
+    "                start_time=parse_datetime(st),\n",
+    "                end_time=parse_datetime(et),\n",
+    "                step=step\n",
+    "            )\n",
+    "            if len(test_inp) > 0:\n",
+    "                df = MetricRangeDataFrame(test_inp)\n",
+    "                results[key].append(df)\n",
+    "        if len(results[key]) > 0:\n",
+    "            results[key] = pd.concat(results[key], axis=0)\n",
+    "        else:\n",
+    "            results.pop(key)\n",
+    "            unique_model_versions.remove(key.split(\"_instances_\")[1])\n",
+    "    gpu_queries = {\"gpu_tensor_util_\"+str(mg): \"sum (avg_over_time(DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{\"+\n",
+    "                   \"exported_container='triton',exported_namespace='triton',prometheus_replica='prometheus-k8s-0',\"+\n",
+    "                   \"device='\"+gpu_inst.split(\"/\")[0]+\"',GPU_I_ID='\"+gpu_inst.split(\"/\")[1]+\"',instance='\"+gpu_inst.split(\"/\")[2]+\"'}[\"+step+\"]))\" for mg, gpu_inst in enumerate(unique_gpu_instances)}\n",
+    "    gpu_queries.update(\n",
+    "        {\"gpu_dram_util_\"+str(mg): \"avg (avg_over_time(DCGM_FI_PROF_DRAM_ACTIVE{\"+\n",
+    "         \"exported_container='triton',exported_namespace='triton',prometheus_replica='prometheus-k8s-0',\"+\n",
+    "        \"device='\"+gpu_inst.split(\"/\")[0]+\"',GPU_I_ID='\"+gpu_inst.split(\"/\")[1]+\"',instance='\"+gpu_inst.split(\"/\")[2]+\"'}[\"+step+\"]))\"\n",
+    "         for mg, gpu_inst in enumerate(unique_gpu_instances)})\n",
+    "    for key, query in gpu_queries.items():\n",
+    "        queries.append((key, query))\n",
+    "        results[key] = []\n",
+    "        for st, et in timestamp_tuples:\n",
+    "            test_inp = prom.custom_query_range(\n",
+    "                query=query,\n",
+    "                start_time=parse_datetime(st),\n",
+    "                end_time=parse_datetime(et),\n",
+    "                step=step\n",
+    "            )\n",
+    "            if len(test_inp) > 0:\n",
+    "                df = MetricRangeDataFrame(test_inp)\n",
+    "                results[key].append(df)\n",
+    "        if len(results[key]) > 0:\n",
+    "            results[key] = pd.concat(results[key], axis=0)\n",
+    "            #print(key)\n",
+    "        else:\n",
+    "            #print(f\"results empty for {key}\")\n",
+    "            results.pop(key)\n",
+    "            unique_gpu_instances.remove(key.split(\"_util_\")[1])\n",
+    "    return results, queries, unique_model_versions, unique_gpu_instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "428998de-695a-4e4b-97d7-59ec468afbf9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "results, queries, unique_model_versions, unique_gpu_instances = get_all_queries([(\"2023-03-30 at 16:00:00 MDT\", \"2023-03-30 at 19:00:00 MDT\"),], step=\"60s\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb863da4-dc44-4e44-863a-962e306b3f2b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "unique_model_versions, unique_gpu_instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7245fa8-2eed-4b0a-8ff4-972c9579c6b4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "results[\"gpu_tensor_util_0\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b12b5d5-22f2-4f06-99ae-c9262b11013d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def convert_results_to_df(results):\n",
+    "    i0 = results[\"inf_rate_net\"].join(results[\"num_instances\"],\n",
+    "                                      how=\"left\", \n",
+    "                                      rsuffix=\"_num_instances\",\n",
+    "                                     )\n",
+    "    i0 = i0.join(results[\"inf_reqs_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_reqs_net\")\n",
+    "    i0 = i0.join(results[\"inf_req_dur_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_req_dur_net\")\n",
+    "    i0 = i0.join(results[\"inf_que_dur_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_que_dur_net\")\n",
+    "    i0 = i0.join(results[\"inf_inp_dur_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_inp_dur_net\")\n",
+    "    i0 = i0.join(results[\"inf_inf_dur_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_inf_dur_net\")\n",
+    "    i0 = i0.join(results[\"inf_out_dur_net\"],\n",
+    "                 how=\"left\",\n",
+    "                 rsuffix=\"_inf_out_dur_net\")\n",
+    "    \n",
+    "    #Add the model metrics\n",
+    "    for model in unique_model_versions:\n",
+    "        itemp = results[\"inf_rate_\" + model].join(results[\"num_instances_\" + model],\n",
+    "                                                  how=\"left\",\n",
+    "                                                  rsuffix=\"_num_instances_\"+model.split(\"/\")[0],\n",
+    "                                                  lsuffix=\"_rate_\"+model.split(\"/\")[0],\n",
+    "                                                 )\n",
+    "        i0 = i0.join(itemp, how=\"left\")\n",
+    "        \n",
+    "    #Add the GPU Instance metrics\n",
+    "    for mg, gpu in enumerate(unique_gpu_instances):\n",
+    "        results[\"gpu_tensor_util_\" + str(mg)].fillna(0, inplace=True)\n",
+    "        results[\"gpu_dram_util_\" + str(mg)].fillna(0, inplace=True)\n",
+    "        itemp = results[\"gpu_tensor_util_\" + str(mg)].join(results[\"gpu_dram_util_\" + str(mg)],\n",
+    "                                                  how=\"left\",\n",
+    "                                                  rsuffix=\"_gpu_dram_util_\"+str(mg),\n",
+    "                                                  lsuffix=\"_gpu_tensor_util_\"+str(mg),\n",
+    "                                                 )\n",
+    "        i0 = i0.join(itemp, how=\"left\")\n",
+    "\n",
+    "    #Get rid of the \"value\" in names, and fill NaN values with 0 everywhere\n",
+    "    i0.rename(columns={\"value\": \"rate\"}, inplace=True)\n",
+    "    i0.rename(columns={col:col[6:] for col in i0.columns if col.startswith(\"value_\")}, inplace=True)\n",
+    "    i0.fillna(0, inplace=True)\n",
+    "    \n",
+    "    #Aggregate some stats for models\n",
+    "    valid_model_keys = [col for col in i0.columns if col.startswith(\"rate_\") and col.replace(\"rate_\", \"num_instances_\") in i0.columns]\n",
+    "    i0[\"summed_rate\"] = sum([i0[col] for col in valid_model_keys])\n",
+    "    i0[\"summed_instances\"] = sum([i0[col.replace(\"rate_\", \"num_instances_\")] for col in valid_model_keys])\n",
+    "    \n",
+    "    #Aggregate some stats for GPU instances\n",
+    "    valid_gpu_keys = [col for col in i0.columns if col.startswith(\"gpu_tensor_util\") and col.replace(\"tensor\", \"dram\") in i0.columns]\n",
+    "    i0[\"summed_gpu_tensor_util\"] = sum([i0[col] for col in valid_gpu_keys])\n",
+    "    i0[\"summed_gpu_dram_util\"] = sum([i0[col.replace(\"tensor\", \"dram\")] for col in valid_model_keys])\n",
+    "    return i0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b72a8b3d-7d38-4b98-8a3a-2d283f4990e6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "i0 = convert_results_to_df(results)\n",
+    "i0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a243ca52-500b-408c-91c3-ab5393c1b1b7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.plot(i0.index.values, i0.rate.values)\n",
+    "scale_value = max(i0.rate.values)/max(i0.summed_gpu_tensor_util)\n",
+    "plt.plot(i0.index.values, i0.summed_gpu_tensor_util.values*scale_value, color=\"tab:red\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88e02198-b119-4df0-a73d-66e8770f5860",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import pickle\n",
+    "with open(f\"triton_metrics_test.pickle\", \"wb\") as output_file:\n",
+    "    pickle.dump(i0, output_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b912b07-fbd3-431b-8d1c-330b63f73aef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Concurrency question: if models tend to gravitate to their own instances, summed instances ~ num_instances\n",
+    "#If concurrency is as high as possible, summed instances ~ avg_num_models * num_instances\n",
+    "ii = i0[i0.num_instances > 0].summed_instances/i0[i0.num_instances > 0].num_instances\n",
+    "print(np.mean(ii), np.max(ii), np.min(ii))\n",
+    "print(np.sqrt(np.var(ii)))\n",
+    "\n",
+    "#Consistency check: summed rate should always add to net rate!\n",
+    "kk = i0[i0.num_instances > 0].summed_rate/i0[i0.num_instances > 0].rate\n",
+    "print(np.mean(kk), np.max(kk), np.min(kk))\n",
+    "print(np.sqrt(np.var(kk)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8a6c219-49ca-49d6-ab2a-e9c00707dcd9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.scatter(\"num_instances\", \"rate\", data=i0[i0.num_instances > 0], color=\"tab:red\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58424494-1247-4eee-9b46-7867e6ef21b5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.scatter(\"num_instances_pn_demo\", \"rate_pn_demo\", data=i0[i0.num_instances > 0], color=\"tab:blue\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c5ddc95-759c-4451-ae45-ab313e4b42c4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "plt.scatter(\"num_instances_svj_tch_gnn\", \"rate_svj_tch_gnn\", data=i0[i0.num_instances > 0], color=\"tab:green\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03e125dc-31af-4d94-828b-a588d07877de",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "coffea for triton",
+   "language": "python",
+   "name": "coffea-triton"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-awkward==1.10.2
+awkward==1.10.3
 tenacity
-git+https://github.com/CoffeaTeam/lpcjobqueue.git@v0.2.7
+git+https://github.com/CoffeaTeam/lpcjobqueue.git@v0.2.10
 prometheus-api-client

--- a/setup.sh
+++ b/setup.sh
@@ -11,7 +11,7 @@ PIP_FILE_IMAGE="requirements.txt"
 PIP_FILE_LOCAL="requirements_noimage.txt"
 
 VENV_NAME="tritonenv"
-COFFEA_IMAGE="coffeateam/coffea-dask:0.7.18-fastjet-3.3.4.0rc9-ga393bf1"
+COFFEA_IMAGE="coffeateam/coffea-dask:0.7.21-fastjet-3.4.0.1-gc3d707c"
 PIP_FILE=$PIP_FILE_IMAGE
 LCG_PATH="/cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc9-opt"
 MODE="IMAGE"

--- a/utils/mlbench.py
+++ b/utils/mlbench.py
@@ -1,0 +1,220 @@
+import psutil
+import os
+import socket
+import pickle
+import time
+import awkward as ak
+import numpy as np
+import torch
+
+
+class SimpleWorkLog:
+    def __init__(self, label=""):
+        self.label = label
+        self.hostname = socket.gethostname()
+        self.pid = os.getpid()
+        self.start_time = None
+        self.end_time = None
+        self.interval = None
+        self.batchsize = []
+        self.bytesize = []
+        
+    def start(self, model_name=None, model_version=None):
+        self.start_time = time.gmtime()
+        self.interval = time.perf_counter()
+        
+    def log_inference(self, batchsize, bytesize):
+        self.batchsize.append(batchsize)
+        self.bytesize.append(bytesize)
+        
+    def end(self):
+        self.interval = time.perf_counter() - self.interval
+        self.end_time = time.gmtime()
+        
+def generate_pseudodata_from_seed(seed, chunksize=20000):
+    """
+    Parameters:
+    seed (int): A seed for pseudo-random number generator
+    chunksize (int): [Optional] Number of pseudo-events to generate, for each of which 1-10 pseudo 'jets'
+    and associated data will be generated
+
+    Returns:
+    record_array (awkward.Array): An awkward record array with 3 fields (points, features, mask)
+    
+    Create data in a format analogous to High Energy Physics data as processed with the scikit-hep ecosystem.
+    This is a stand-in for loading data stored in .root files via coffea
+    """
+    grdn = np.random.default_rng(seed)
+    njets = ak.Array(grdn.integers(1, 10, size=chunksize))
+    total_jets = np.sum(njets)    
+    #points = ak.unflatten(grdn.random((total_jets, 2, 100), dtype=np.float32), njets)
+    #features = ak.unflatten(grdn.random((total_jets, 5, 100), dtype=np.float32), njets)
+    #mask = ak.unflatten(grdn.random((total_jets, 1, 100), dtype=np.float32), njets)
+    return ak.unflatten(ak.Array({
+        "points": grdn.random((total_jets, 2, 100), dtype=np.float32),
+        "features": grdn.random((total_jets, 5, 100), dtype=np.float32),
+        "mask": grdn.random((total_jets, 1, 100), dtype=np.float32)
+    }),njets)
+
+def run_inference_pnmodel(record_array, model, batchsize=1024, triton=False, worklog=SimpleWorkLog):
+    """
+    Parameters:
+    record_array (awkward.Array): An awkward record array with 3 fields (points, features, mask)
+    batchsize (int): Desired batchsize
+    triton (bool): [Default: False] return data as a dict for triton inference, else a list for local inference
+    
+    Returns:
+    inference_outputs (awkward.Array): An awkward array of inference results
+    worklogs (list): List of worklogs tracking stats about the inference
+    errors (None | list): List of triton inference errors, if any
+    
+    Restructure data from scikit-hep format to one suitable for inference (batched) with triton or local ParticleNet
+    """
+    counts, flattened_record = ak.num(record_array), ak.flatten(record_array)
+    total_records = len(flattened_record)
+    outputs = []
+    worklogs = []
+    errors = []
+    for start in range(0, total_records, batchsize):
+        stop = min(total_records, start + batchsize)
+        #try:
+        #    dask.distributed.get_worker().log_event("run_inference_pnmodel", {
+        #        "triton": triton,
+        #        "batchsize": batchsize,
+        #        "len": total_records,
+        #        "progress": start/total_records
+        #    })
+        #except:
+        #    pass
+        nbytes = 0
+        if triton:
+            # Restructure
+            worklogs.append(SimpleWorkLog("RestructureInputs"))
+            worklogs[-1].start()
+            X = dict()
+            X["points__0"] = ak.to_numpy(flattened_record["points", start:stop]);
+            X["features__1"] = ak.to_numpy(flattened_record["features", start:stop])
+            X["mask__2"] = ak.to_numpy(flattened_record["mask", start:stop])
+            for val in X.values():
+                nbytes += val.nbytes
+            worklogs[-1].end()
+            
+            worklogs.append(SimpleWorkLog("Inference"))
+            worklogs[-1].start(model._model, model._version)
+            worklogs[-1].log_inference(stop-start, nbytes)
+            temp = model(X)
+            if isinstance(temp, np.ndarray):
+                outputs.append(temp)
+            else:
+                #Could make the output array Option type and fill with Nones instead of -1
+                outputs.append(-1*np.ones_like(X["points__0"], dtype=np.float32))
+                errors.append((start, stop, temp))
+            worklogs[-1].end()
+        else:
+            # Restructure
+            worklogs.append(SimpleWorkLog("RestructureInputs"))
+            worklogs[-1].start()
+            X = []
+            for field in ["points", "features", "mask"]:
+                X.append(torch.from_numpy(ak.to_numpy(flattened_record[field, start:stop])))        
+            for val in X:
+                nbytes += val.nelement() * val.element_size()
+            worklogs[-1].end()
+            
+            #Run Inference
+            with torch.no_grad():
+                worklogs.append(SimpleWorkLog("Inference"));
+                worklogs[-1].start("pn_demo", "1") #FIXME Add model/version dynamically
+                worklogs[-1].log_inference(stop-start, nbytes)
+                try:
+                    temp = model(*X).detach().numpy()
+                    outputs.append(temp)
+                except Exception as inst:
+                    outputs.append(-1*np.ones_like(X[0], dtype=np.float32))
+                    errors.append((start, stop, inst))
+                worklogs[-1].end()
+    output = np.concatenate(outputs, axis=0)
+    flattened_record = ak.with_field(flattened_record, output, "output")
+    return ak.unflatten(flattened_record, counts), worklogs, errors
+    
+def get_triton_client(model_and_version="pn_demo/1", server="triton+grpc://triton.apps.okddev.fnal.gov:443/"):
+    """
+    Parameters:
+    model_and_version (str): Name and version of the desired model on the triton server (e.g. 'pn_demo/1')
+    server (str): protocol and address of server (e.g. 'triton+grpc://triton.apps.okddev.fnal.gov:443/')
+    
+    Returns:
+    triton_model_client (triton client): A client capable of running inference on 
+    
+    Create data in a format analogous to High Energy Physics data as processed with the scikit-hep ecosystem.
+    This is a stand-in for loading data stored in .root files via coffea
+    """
+    from utils.tritonutils import wrapped_triton
+
+    # create instance of triton model
+    triton_model = wrapped_triton(server + model_and_version)
+    return triton_model
+
+def create_local_pnmodel():
+    from models.ParticleNet import ParticleNetTagger
+    import torch
+
+    # load in local model
+    local_model = ParticleNetTagger(5, 2,
+                            [(16, (64, 64, 64)), (16, (128, 128, 128)), (16, (256, 256, 256))],
+                            [(256, 0.1)],
+                            use_fusion=True,
+                            use_fts_bn=False,
+                            use_counts=True,
+                            for_inference=False)
+
+    LOCAL_PATH = "/srv/models/pn_demo.pt"
+    local_model.load_state_dict(torch.load(LOCAL_PATH, map_location=torch.device('cpu')))
+    local_model.eval()
+    return local_model
+
+def process_function(seed, chunksize=1000, batchsize=1024, triton=False, worklog=SimpleWorkLog):
+    #import importlib
+    #from utils.mlbench import SimpleWorkLog as worklog
+    worklogs = []
+    
+    # Generate the Pseudodata
+    worklogs.append(worklog(label="GeneratePseudodata"))
+    worklogs[-1].start()
+    inputs = generate_pseudodata_from_seed(seed, chunksize)
+    worklogs[-1].end()
+    
+    # Create Model and run restructuring and inference
+    local_model = None
+    triton_model = None
+    errors = None
+    if triton:
+        triton_model = get_triton_client()
+        with_outputs, inf_worklogs, errors = run_inference_pnmodel(
+            inputs, 
+            triton_model, 
+            batchsize=batchsize, 
+            triton=True, 
+            worklog=SimpleWorkLog
+        )
+    else:
+        local_model = create_local_pnmodel()
+        with_outputs, inf_worklogs, errors = run_inference_pnmodel(
+            inputs, 
+            local_model, 
+            batchsize=batchsize, 
+            triton=False, 
+            worklog=SimpleWorkLog
+        )
+    worklogs += inf_worklogs
+    
+    return {"worklogs": worklogs, 
+            "output_desc": {"type": with_outputs.type, 
+                            "fields": with_outputs.fields,
+                            "layout": str(with_outputs.layout),
+                            "disc_mean": np.mean(with_outputs.output),
+                           },
+            "triton_errors": errors,
+           }
+    
+#Additional model to test: https://github.com/suyong-choi/ABCDnn


### PR DESCRIPTION
Updates the install settings to avoid the awkward1 memory leak, updates to jupyter lab, adds notebooks for running benchmark from dask workers without coffea, adds prometheus query metrics and some rough plots of utilization and inference rates